### PR TITLE
imp: support Ubuntu 20.04 and update CentOS to 7.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 *.swp
 .bundle/
 vendor/
-Gemfile.lock

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -48,9 +48,14 @@ platforms:
       box: trombik/ansible-ubuntu-18.04-amd64
       box_check_update: false
 
-  - name: centos-7.4-x86_64
+  - name: ubuntu-20.04-amd64
     driver:
-      box: trombik/ansible-centos-7.4-x86_64
+      box: trombik/ansible-ubuntu-20.04-amd64
+      box_check_update: false
+
+  - name: centos-7.8-x86_64
+    driver:
+      box: trombik/ansible-centos-7.8-x86_64
       box_check_update: false
 
 suites:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,180 @@
+GIT
+  remote: https://github.com/trombik/kitchen-sync.git
+  revision: d1d14052e3f401d87986eaffdf5d117518c8bd68
+  branch: without_full_path_to_rsync
+  specs:
+    kitchen-sync (2.1.2.pre)
+      net-sftp
+      test-kitchen (>= 1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.1)
+    bcrypt_pbkdf (1.0.1)
+    builder (3.2.4)
+    chef-utils (16.4.41)
+    diff-lcs (1.4.4)
+    ed25519 (1.2.4)
+    erubi (1.9.0)
+    ffi (1.13.1)
+    gssapi (1.3.0)
+      ffi (>= 1.0.1)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
+    httpclient (2.8.3)
+    kitchen-ansible (0.52.0)
+      net-ssh (>= 3)
+      test-kitchen (>= 1.4)
+    kitchen-vagrant (1.7.0)
+      test-kitchen (>= 1.4, < 3)
+    license-acceptance (2.0.0)
+      pastel (~> 0.7)
+      tomlrb (~> 1.2)
+      tty-box (~> 0.6)
+      tty-prompt (~> 0.20)
+    little-plugger (1.1.4)
+    logging (2.3.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.14)
+    mixlib-install (3.12.3)
+      mixlib-shellout
+      mixlib-versioning
+      thor
+    mixlib-shellout (3.1.4)
+      chef-utils
+    mixlib-versioning (1.2.12)
+    multi_json (1.15.0)
+    net-scp (3.0.0)
+      net-ssh (>= 2.6.5, < 7.0.0)
+    net-sftp (3.0.0)
+      net-ssh (>= 5.0.0, < 7.0.0)
+    net-ssh (6.1.0)
+    net-ssh-gateway (2.0.0)
+      net-ssh (>= 4.0.0)
+    net-telnet (0.1.1)
+    nori (2.6.0)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
+    pastel (0.8.0)
+      tty-color (~> 0.5)
+    rainbow (3.0.0)
+    rake (13.0.1)
+    regexp_parser (1.7.1)
+    rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
+    rspec-support (3.9.3)
+    rubocop (0.90.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.3.0, < 1.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
+    ruby-progressbar (1.10.1)
+    rubyntlm (0.6.2)
+    rubyzip (2.3.0)
+    serverspec (2.41.5)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.72)
+    sfl (2.3)
+    specinfra (2.82.19)
+      net-scp
+      net-ssh (>= 2.7)
+      net-telnet (= 0.1.1)
+      sfl
+    strings (0.2.0)
+      strings-ansi (~> 0.2)
+      unicode-display_width (~> 1.5)
+      unicode_utils (~> 1.4)
+    strings-ansi (0.2.0)
+    test-kitchen (2.6.0)
+      bcrypt_pbkdf (~> 1.0)
+      ed25519 (~> 1.2)
+      license-acceptance (>= 1.0.11, < 3.0)
+      mixlib-install (~> 3.6)
+      mixlib-shellout (>= 1.2, < 4.0)
+      net-scp (>= 1.1, < 4.0)
+      net-ssh (>= 2.9, < 7.0)
+      net-ssh-gateway (>= 1.2, < 3.0)
+      thor (>= 0.19, < 2.0)
+      winrm (~> 2.0)
+      winrm-elevated (~> 1.0)
+      winrm-fs (~> 1.1)
+    thor (1.0.1)
+    tomlrb (1.3.0)
+    tty-box (0.6.0)
+      pastel (~> 0.8)
+      strings (~> 0.2.0)
+      tty-cursor (~> 0.7)
+    tty-color (0.5.2)
+    tty-cursor (0.7.1)
+    tty-prompt (0.22.0)
+      pastel (~> 0.8)
+      tty-reader (~> 0.8)
+    tty-reader (0.8.0)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.8)
+      wisper (~> 2.0)
+    tty-screen (0.8.1)
+    unicode-display_width (1.7.0)
+    unicode_utils (1.4.0)
+    winrm (2.3.4)
+      builder (>= 2.1.2)
+      erubi (~> 1.8)
+      gssapi (~> 1.2)
+      gyoku (~> 1.0)
+      httpclient (~> 2.2, >= 2.2.0.2)
+      logging (>= 1.6.1, < 3.0)
+      nori (~> 2.0)
+      rubyntlm (~> 0.6.0, >= 0.6.1)
+    winrm-elevated (1.2.1)
+      erubi (~> 1.8)
+      winrm (~> 2.0)
+      winrm-fs (~> 1.0)
+    winrm-fs (1.3.4)
+      erubi (~> 1.8)
+      logging (>= 1.6.1, < 3.0)
+      rubyzip (~> 2.0)
+      winrm (~> 2.0)
+    wisper (2.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  kitchen-ansible
+  kitchen-sync (~> 2.1.1)!
+  kitchen-vagrant
+  rake
+  rspec
+  rspec-retry
+  rubocop
+  serverspec
+  test-kitchen
+
+BUNDLED WITH
+   1.17.3

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - focal
     - name: EL
       versions:
         - 7

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -11,7 +11,7 @@
       - https://deb.nodesource.com/gpgkey/nodesource.gpg.key
     apt_repo_enable_apt_transport_https: yes
     apt_repo_to_add:
-      - "deb https://deb.nodesource.com/node_8.x {{ ansible_distribution_release }} main"
+      - "deb https://deb.nodesource.com/node_10.x {{ ansible_distribution_release }} main"
     # XXX npm is included in nodejs from deb.nodesource.com
     nodejs_npm_package: "{% if ansible_os_family == 'Debian' %}nodejs{% else %}npm{% endif %}"
     redhat_repo:

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -14,6 +14,7 @@ when "redhat"
   package_npm = "npm"
 when "ubuntu"
   package_npm = "nodejs"
+  nodejs_command = os[:release].to_f < 20.04 ? "nodejs" : "node"
 when "freebsd"
   package = "www/node"
   package_npm = "www/npm"
@@ -38,7 +39,7 @@ describe command "#{nodejs_command} --version" do
   its(:stderr) { should be_empty }
   case os[:family]
   when "ubuntu"
-    its(:stdout) { should match(/^v8\.\d+\.\d+$/) }
+    its(:stdout) { should match(/^v10\.\d+\.\d+$/) }
   else
     its(:stdout) { should match(/^v\d+\.\d+\.\d+$/) }
   end


### PR DESCRIPTION
node 8.x does not support Ubuntu 20.04 (the repo does not have node
package for 20.04).